### PR TITLE
reverse_iterator for get

### DIFF
--- a/Jzon.cpp
+++ b/Jzon.cpp
@@ -348,7 +348,7 @@ namespace Jzon
 		if (isObject())
 		{
 			NamedNodeList &children = data->children;
-			for (NamedNodeList::const_iterator it = children.begin(); it != children.end(); ++it)
+			for (NamedNodeList::const_reverse_iterator it = children.rbegin(); it != children.rend(); ++it)
 			{
 				if ((*it).first == name)
 				{


### PR DESCRIPTION
When we have duplicate keys in json, the `get` must return the last key. http://stackoverflow.com/a/5306792/4895167.
I tried to figure out the behaviour of JS machine in Chrome. `JSON.parse('{"a":"a","a":"b"}')` will give `{a:"b"}`. 