### PR TITLE
GET_NUMBER

### DIFF
--- a/Jzon.cpp
+++ b/Jzon.cpp
@@ -144,12 +144,15 @@ namespace Jzon
 		}
 	}
 #define GET_NUMBER(T) \
-	if (isNumber())\
+	if (isValue())\
 	{\
 		std::stringstream sstr(data->valueStr);\
-		T val;\
+		double val;\
+        std::string remain;\
 		sstr >> val;\
-		return val;\
+        if(sstr.fail()) return def;\
+        sstr >> remain;\
+        return remain.empty() ? val : def;\
 	}\
 	else\
 	{\

--- a/Jzon.h
+++ b/Jzon.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <istream>
 #include <ostream>
 
+
 #ifndef JZON_API
 #	ifdef JZON_DLL
 #		if defined _WIN32 || defined __CYGWIN__


### PR DESCRIPTION
There may be the situation when `node` have `isValue() = true` and `isNumber() = false`. In this case `toNumber()` get default value, but it can transform to number.