### PR TITLE
Avoiding string temps, adding move operations, and removing manual reference counting

### DIFF
--- a/Jzon.cpp
+++ b/Jzon.cpp
@@ -93,10 +93,12 @@ namespace Jzon
 	}
 	Node::Node(Type type, const std::string &value) : data(std::make_shared<Data>(T_NULL)) { set(type, value); }
 	Node::Node(const std::string &value) : data(std::make_shared<Data>(T_STRING)) { set(value); }
-	Node::Node(std::string value) : data(std::make_shared<Data>(T_STRING)) { set(std::move(value)); }
+	Node::Node(std::string&& value) : data(std::make_shared<Data>(T_STRING)) { set(std::move(value)); }
 	Node::Node(const char *value) : data(std::make_shared<Data>(T_STRING)) { set(value); }
 	Node::Node(int value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
 	Node::Node(unsigned int value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
+	Node::Node(long value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
+	Node::Node(unsigned long value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
 	Node::Node(long long value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
 	Node::Node(unsigned long long value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }
 	Node::Node(float value) : data(std::make_shared<Data>(T_NUMBER)) { set(value); }

--- a/Jzon.h
+++ b/Jzon.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <iterator>
 #include <istream>
 #include <ostream>
+#include <sstream>
 
 #ifndef JZON_API
 #	ifdef JZON_DLL
@@ -151,10 +152,13 @@ namespace Jzon
 
 		void setNull();
 		void set(Type type, const std::string &value);
+		void set(Type type, const char *value);
 		void set(const std::string &value);
 		void set(const char *value);
 		void set(int value);
 		void set(unsigned int value);
+		void set(long value);
+		void set(unsigned long value);
 		void set(long long value);
 		void set(unsigned long long value);
 		void set(float value);
@@ -166,6 +170,8 @@ namespace Jzon
 		Node &operator=(const char *rhs);
 		Node &operator=(int rhs);
 		Node &operator=(unsigned int rhs);
+		Node &operator=(long rhs);
+		Node &operator=(unsigned long rhs);
 		Node &operator=(long long rhs);
 		Node &operator=(unsigned long long rhs);
 		Node &operator=(float rhs);
@@ -174,6 +180,7 @@ namespace Jzon
 
 		void add(const Node &node);
 		void add(const std::string &name, const Node &node);
+		void add(std::string &&name, const Node &node);
 		void append(const Node &node);
 		void remove(size_t index);
 		void remove(const std::string &name);
@@ -181,6 +188,7 @@ namespace Jzon
 
 		bool has(const std::string &name) const;
 		size_t getCount() const;
+		Node get(const char *name) const;
 		Node get(const std::string &name) const;
 		Node get(size_t index) const;
 
@@ -194,11 +202,25 @@ namespace Jzon
 		inline operator bool() const { return isValid(); }
 
 	private:
+		template <typename T>
+		inline void set_number(T value)
+		{
+			if (isValue())
+			{
+				detach();
+				data->type = T_NUMBER;
+				std::ostringstream sstr;
+				sstr << value;
+				data->valueStr = sstr.str();
+			}
+		}
+
 		typedef std::vector<NamedNode> NamedNodeList;
 		struct Data
 		{
 			explicit Data(Type type);
 			Data(const Data &other);
+			Data(Data &&other);
 			~Data();
 			void addRef();
 			bool release();
@@ -212,6 +234,7 @@ namespace Jzon
 
 	JZON_API std::string escapeString(const std::string &value);
 	JZON_API std::string unescapeString(const std::string &value);
+	JZON_API std::string unescapeString(const char *value);
 
 	JZON_API Node invalid();
 	JZON_API Node null();

--- a/Jzon.h
+++ b/Jzon.h
@@ -22,13 +22,14 @@ THE SOFTWARE.
 #ifndef Jzon_h__
 #define Jzon_h__
 
-#include <string>
-#include <vector>
-#include <queue>
 #include <iterator>
 #include <istream>
+#include <memory>
 #include <ostream>
+#include <queue>
+#include <string>
 #include <sstream>
+#include <vector>
 
 #ifndef JZON_API
 #	ifdef JZON_DLL
@@ -117,8 +118,10 @@ namespace Jzon
 		Node();
 		explicit Node(Type type);
 		Node(const Node &other);
+		Node(Node &&other);
 		Node(Type type, const std::string &value);
 		Node(const std::string &value);
+		Node(std::string value);
 		Node(const char *value);
 		Node(int value);
 		Node(unsigned int value);
@@ -152,6 +155,7 @@ namespace Jzon
 
 		void setNull();
 		void set(Type type, const std::string &value);
+		void set(Type type, std::string&& value);
 		void set(Type type, const char *value);
 		void set(const std::string &value);
 		void set(const char *value);
@@ -166,7 +170,9 @@ namespace Jzon
 		void set(bool value);
 
 		Node &operator=(const Node &rhs);
+		Node &operator=(Node &&rhs);
 		Node &operator=(const std::string &rhs);
+		Node &operator=(std::string&& rhs);
 		Node &operator=(const char *rhs);
 		Node &operator=(int rhs);
 		Node &operator=(unsigned int rhs);
@@ -180,12 +186,14 @@ namespace Jzon
 
 		void add(const Node &node);
 		void add(const std::string &name, const Node &node);
-		void add(std::string &&name, const Node &node);
+		void add(std::string&& name, const Node &node);
 		void append(const Node &node);
 		void remove(size_t index);
+		void remove(const char *name);
 		void remove(const std::string &name);
 		void clear();
 
+		bool has(const char *name) const;
 		bool has(const std::string &name) const;
 		size_t getCount() const;
 		Node get(const char *name) const;
@@ -222,14 +230,13 @@ namespace Jzon
 			Data(const Data &other);
 			Data(Data &&other);
 			~Data();
-			void addRef();
-			bool release();
-			int refCount;
 
 			Type type;
 			std::string valueStr;
 			NamedNodeList children;
-		} *data;
+		};
+
+		std::shared_ptr<Data> data;
 	};
 
 	JZON_API std::string escapeString(const std::string &value);

--- a/Jzon.h
+++ b/Jzon.h
@@ -121,10 +121,12 @@ namespace Jzon
 		Node(Node &&other);
 		Node(Type type, const std::string &value);
 		Node(const std::string &value);
-		Node(std::string value);
+		Node(std::string&& value);
 		Node(const char *value);
 		Node(int value);
 		Node(unsigned int value);
+		Node(long value);
+		Node(unsigned long value);
 		Node(long long value);
 		Node(unsigned long long value);
 		Node(float value);


### PR DESCRIPTION
-Added `const char *` parameter to parts of the interface to allow for the option of preventing temp strings from being created
-Added `move` operations to several locations where they could be used without much change to existing logic
-Removed the `SET_NUMBER` macro in favor of templatization
-Added `unsigned long` and `long` parameter versions of `Node` to help users avoid having to `static_cast` to one of the existing types
-Removed manual reference counting and replaced with `std::shared_ptr`